### PR TITLE
Fix UAC not working properly

### DIFF
--- a/Src/Public/Set-RegistryProperties.ps1
+++ b/Src/Public/Set-RegistryProperties.ps1
@@ -48,7 +48,6 @@ Function Set-RegistryProperties
         $RegistryData.DisableTelemetry | Out-File -FilePath $RegistryLog -Encoding UTF8 -Append -Force
         If ($DynamicParams.LTSC -or $InstallInfo.Name -like "*Enterprise*" -or $InstallInfo.Name -like "*Education*") { $TelemetryLevel = 0 } Else { $TelemetryLevel = 1 }
         RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" -Name "AllowTelemetry" -Value $TelemetryLevel -Type DWord
-        RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Policies\DataCollection" -Name "AllowTelemetry" -Value $TelemetryLevel -Type DWord
         RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\DataCollection" -Name "AllowTelemetry" -Value $TelemetryLevel -Type DWord
         RegKey -Path "HKLM:\WIM_HKLM_SOFTWARE\Policies\Microsoft\Windows\DataCollection" -Name "DoNotShowFeedbackNotifications" -Value 1 -Type DWord
         RegKey -Path "HKLM:\WIM_HKCU\SOFTWARE\Policies\Microsoft\Windows\CloudContent" -Name "DisableTailoredExperiencesWithDiagnosticData" -Value 1 -Type DWord


### PR DESCRIPTION
I recently installed Windows 10 using an ISO created by Optimize-Offline and noticed some unusual UAC behavior (or lack thereof).
When running an installer, e.g. Firefox's, usually Windows detects this and requests elevation:
![](https://user-images.githubusercontent.com/29805476/73395971-bed59f80-42e0-11ea-8b56-991064cdc173.gif)
On the optimized Windows installation (with `"Registry": true` in `Configuration.json`), this doesn't work:
![](https://user-images.githubusercontent.com/29805476/73396255-47544000-42e1-11ea-977c-fbbf564c3281.gif)
(Note that the "Run as" dialog here is provided by the installer, not Windows.)

The cause of this issue is that setting `HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Policies\DataCollection\AllowTelemetry` causes the entire `HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Policies` branch (which also contains keys related to UAC) to be empty apart from that value.
![](https://user-images.githubusercontent.com/29805476/73397036-eb8ab680-42e2-11ea-912a-1b47513bfc09.png)
Removing the line that sets this value from `Set-RegistryProperties.ps1` fixes this, and `AllowTelemetry` is still set to the correct value because it is automatically copied from the corresponding non-`WOW6432Node` registry key.
![](https://user-images.githubusercontent.com/29805476/73397460-de21fc00-42e3-11ea-8002-7232d0caed06.png)
![](https://user-images.githubusercontent.com/29805476/73397468-e11cec80-42e3-11ea-97a7-003e1aac6137.png)

